### PR TITLE
修复 export default defineComponent 

### DIFF
--- a/example/App.jsx
+++ b/example/App.jsx
@@ -1,7 +1,7 @@
 import { defineComponent } from 'vue';
 import A from './A';
 import { B } from './B';
-
+import C from './C'
 const App = defineComponent({
   data() {
     return {
@@ -16,6 +16,7 @@ const App = defineComponent({
         <div onClick={() => { this.a++; }}>Hello World!</div>
         <A />
         <B />
+        <C />
       </>
     )
   }

--- a/example/C.jsx
+++ b/example/C.jsx
@@ -1,0 +1,18 @@
+import {defineComponent, onMounted, ref} from 'vue';
+
+export default defineComponent({
+    setup() {
+        onMounted(() => {
+            console.log('C')
+        })
+        const c = ref(0)
+        return () => (<>
+            <div onClick={() => {
+                c.value++
+            }}> 点我加一个
+            </div>
+            <span>我是点C 我的值是 {c.value}</span>
+        </>)
+    }
+});
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export default function loader(
       if (t.isIdentifier(declaration)) {
         if (declaredComponents.find(d => d.name === declaration.name)) {
           hotComponents.push({
-            local: '__default__',
+            local: declaration.name,
             id: hash(`${filename}-default`)
           })
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export default function loader(
           local: '__default__',
           id: hash(`${filename}-default`)
         });
+        hasDefault = true
       }
     }
   }


### PR DESCRIPTION
在跟新到 0.1.3 之后 发现 const App = defineComponent    export default defineComponent  这些写法     报   __default__    undefined  异常 对比 0.1.2 尝试修复 。目前  const App = defineComponent    export default defineComponent 已兼容
不确定 0.1.3 说的 class 装饰器写法是否存在问题